### PR TITLE
trust-registry kong plugin build and testing using OpenSpec

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ Thumbs.db
 
 # Logs
 *.log
+
+# Local OpenSpec CLI install
+.tools/
+
+# Claude Code local settings (may contain personal config)
+.claude/settings.local.json

--- a/docker-compose.validate.yml
+++ b/docker-compose.validate.yml
@@ -11,7 +11,7 @@ services:
     environment:
       KONG_DATABASE: "off"
       KONG_DECLARATIVE_CONFIG: /etc/kong/kong.yaml
-      KONG_PLUGINS: "bundled,trust-registry-ai"
+      KONG_PLUGINS: "bundled,trust-registry-ai-openspec"
       KONG_ADMIN_LISTEN: "0.0.0.0:8001"
       KONG_PROXY_LISTEN: "0.0.0.0:8000"
       KONG_LOG_LEVEL: info

--- a/docs/openspec-readme.md
+++ b/docs/openspec-readme.md
@@ -1,0 +1,369 @@
+# Creating plugins using spec-driven development (OpenSpec and Claude Code)
+
+This document captures the process of creating a new Kong plugin using spec-driven development (SDD) with [OpenSpec](https://github.com/Fission-AI/OpenSpec) and Claude Code. Along with step-by-step usage instructions, some broader commentary on the process from a user standpoint is included.
+
+The OpenSpec AI plugin is in `plugins/trust-registry-ai-openspec`. The Spec-Kit AI plugin (`plugins/trust-registry-ai`) and human plugin (`plugins/trust-registry`) are left unchanged for comparison. OpenSpec artifacts live under `openspec/` (archived change in `openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/`, merged spec in `openspec/specs/jwks-endpoint/`).
+
+- [Human vs Spec-Kit AI](../specs/001-jwks-endpoint/comparison-report.md)
+- [Human vs OpenSpec AI](../specs/001-jwks-endpoint/comparison-report-openspec.md)
+- [Spec-Kit vs OpenSpec workflow](../specs/001-jwks-endpoint/speckit-vs-openspec.md)
+
+## Why OpenSpec?
+
+OpenSpec addresses several concerns identified during the Spec-Kit experience:
+
+- **Lighter workflow** — 3 core phases by default (propose → apply → archive), with optional deeper phases (`explore`, `sync`, `verify`, or expanded `new` / `continue` / `ff`)
+- **Better for brownfield** — supports *delta specs* that describe only what changes, rather than requiring a full feature specification
+- **More iterative** — proposals and design can be updated as new information surfaces
+- **Spec drift mitigation** — `/opsx:archive` merges delta specs into `openspec/specs/` and moves the change to an archive folder
+
+## Branch and clean-room setup
+
+Use branch `001-jwks-endpoint-openspec` for OpenSpec work. **Do not modify** Spec-Kit outputs:
+
+- `plugins/trust-registry-ai/` — Spec-Kit plugin (frozen)
+- `specs/001-jwks-endpoint/` — Spec-Kit specs/plan/tasks (frozen)
+
+OpenSpec implementation goes in **`plugins/trust-registry-ai-openspec/`**. Wall off `trust-registry`, `trust-registry-ai`, and `specs/001-jwks-endpoint` during generation.
+
+After the OpenSpec run, merge into `001-jwks-endpoint` for side-by-side comparison (both AI plugins present).
+
+## Setup
+
+### 1. Install OpenSpec
+
+Requires **Node.js ≥ 20.19.0**.
+
+Global install:
+
+```sh
+npm install -g @fission-ai/openspec@latest
+```
+
+Or install locally in the repo (used in this project):
+
+```sh
+npm install @fission-ai/openspec@latest --prefix .tools
+export PATH="$PWD/.tools/node_modules/.bin:$PATH"
+```
+
+Verify:
+
+```sh
+openspec --version
+```
+
+### 2. Install Claude Code (or other agent of your choice)
+
+```sh
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+If using an API key, set the `ANTHROPIC_API_KEY` environment variable:
+
+```sh
+export ANTHROPIC_API_KEY="your-api-key-here"
+```
+
+Verify (may need to restart WSL with `wsl --shutdown`, or restart your machine):
+
+```bash
+claude
+```
+
+Set theme and choose *Yes* to use the API key.
+
+### 3. Initialize in an existing project
+
+From the repo root:
+
+```sh
+openspec init . --tools claude --force
+```
+
+This creates:
+
+- `openspec/specs/`, `openspec/changes/`, `openspec/config.yaml`
+- `.claude/skills/openspec-*` and `.claude/commands/opsx/`
+
+Restart the terminal (or Claude Code) after init so slash commands are available.
+
+Add Kong plugin context to `openspec/config.yaml` (optional but recommended):
+
+```yaml
+schema: spec-driven
+
+context: |
+  Kong OSS plugin repository. Lua (LuaJIT), Kong PDK only.
+  Plugin layout: plugins/<name>/src/{handler,schema}.lua + rockspec.
+  Follow patterns from existing plugins; do not read plugins/trust-registry or plugins/trust-registry-ai.
+  Output plugin: plugins/trust-registry-ai-openspec/
+```
+
+### 4. Wall off the existing target plugin from the agent
+
+Create or edit `.claude/settings.local.json`:
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Read(plugins/trust-registry/**)",
+      "Read(plugins/trust-registry-ai/**)",
+      "Read(specs/001-jwks-endpoint/**)"
+    ]
+  }
+}
+```
+
+> **Note:** Search can still surface file names. For strict clean-room runs, consider denying search/glob on those paths or removing the directories from the branch before starting.
+
+### 5. Open Claude Code
+
+`--verbose` shows token usage. Use **Opus 4.6** for planning; **Sonnet 4.6** for implementation (same models as the [Spec-Kit run](./spec-driven-development.md)).
+
+```sh
+claude --verbose --model claude-opus-4-6
+```
+
+---
+
+## Using OpenSpec and Claude Code
+
+OpenSpec’s default **`core` profile** maps to three practical phases. Optional commands are listed at the end.
+
+| Phase | Spec-Kit analogue | OpenSpec command | Model |
+|-------|-------------------|------------------|-------|
+| 1 — Plan | constitution + specify + plan + tasks | `/opsx:propose` | Opus |
+| 2 — Implement | implement | `/opsx:apply` | Sonnet |
+| 3 — Archive | (manual spec sync) | `/opsx:archive` | Either |
+
+### Phase 1 — Propose (planning artifacts)
+
+Creates `openspec/changes/<name>/` with `proposal.md`, delta `specs/`, `design.md`, and `tasks.md` in one step.
+
+In Claude Code:
+
+```text
+/opsx:propose trust-registry-ai-jwks
+```
+
+If Claude shows a multiple-choice menu about “AI trust registry” scope, choose **Type something** and paste the block below. The change name `trust-registry-ai-jwks` is only a folder label; the feature is the same JWKS publisher as the [Spec-Kit run](./spec-driven-development.md).
+
+Paste this text **verbatim** for a fair comparison (matches `/speckit-specify` + `/speckit-plan`, with only the plugin name changed for a separate output directory):
+
+```text
+Story: As an SDX Edge Server host, I want to be able to publish my Edge Server public keys, so that other Edge Servers can use it to validate any JSON Web Signature (JWS) documents that my server creates.
+
+Technical background: The SDX Edge Server host will be able to use a gateway pattern to register public keys.  To make these keys available to others, there has to be an endpoint that takes the Kong `keys` and `keysets` and returns a document in JWK Set (JWKS) (RFC-7517) format.  The endpoint should be able to return all keys or provide a keyset path parameter and return only the keys for that particular keyset.  Kong's keys entity allows for storing a pem formatted public key or a jwk.  A JWKS always returns jwk objects so it will need to convert the pem to a jwk while building the response document.
+
+A decision was made to use a Kong plugin to perform this logic, where the route will be:
+paths:
+  - '/.well-known/jwks.json'
+  - '~/keysets/(?<key_set>.+)/.well-known/jwks.json'
+method:
+  - GET
+
+The Kong plugin does not need any configuration parameters.  It will use the optional key_set path parameter to filter the results.
+
+Name the plugin `trust-registry-ai-openspec`. No explicit technical constraints beyond those in the written specification. All implementation details must strictly adhere to Kong plugin guidelines and the stated spec; avoid undocumented behaviors, dependencies, or design assumptions.
+```
+
+**Comparison note:** Do not add extra hints (e.g. “survey lua-resty-openssl”) that Spec-Kit did not receive. Document any process differences in [speckit-vs-openspec.md](../specs/001-jwks-endpoint/speckit-vs-openspec.md) instead.
+
+If a change folder already exists from an earlier attempt, remove it before re-running propose:
+
+```sh
+rm -rf openspec/changes/trust-registry-ai-jwks
+rm -rf plugins/trust-registry-ai-openspec   # only if you want a fresh apply
+```
+
+**Artifacts produced:**
+
+```text
+openspec/changes/trust-registry-ai-jwks/
+├── proposal.md
+├── design.md
+├── tasks.md
+├── specs/jwks-endpoint/spec.md   # delta spec (ADDED/MODIFIED/REMOVED)
+└── .openspec.yaml
+```
+
+CLI equivalents (if not using slash commands):
+
+```sh
+openspec new change "trust-registry-ai-jwks"
+openspec status --change trust-registry-ai-jwks
+openspec instructions proposal --change trust-registry-ai-jwks --json
+# ... create each artifact per instructions, then re-check status
+```
+
+**Phase 1 (this run):** `/opsx:propose` on **Opus 4.6** (~3m 13s). Billed usage is in the [Costs](#costs) table (Opus row). Spec-Kit planning was ~**$2.61** Opus alone for constitution + specify + plan + tasks ([spec-driven-development.md](./spec-driven-development.md)).
+
+---
+
+### Phase 2 — Apply (implementation)
+
+Switch to Sonnet 4.6 to reduce cost:
+
+```text
+/model
+```
+
+Select `Sonnet`. Switching models clears conversation history; decisions should live in the change artifacts.
+
+In Claude Code:
+
+```text
+/opsx:apply trust-registry-ai-jwks
+```
+
+The agent reads `proposal.md`, `design.md`, `specs/`, and `tasks.md`, implements the plugin, and checks off tasks in `tasks.md`.
+
+**Output:** `plugins/trust-registry-ai-openspec/` (and any validation assets referenced in tasks).
+
+**Phase 2 (this run):** `/opsx:apply` on **Sonnet 4.6** (~2m 40s), including in-session Docker checks (tasks 5.1–5.3). Most of the Sonnet row in [Costs](#costs) is apply + archive. Spec-Kit `/speckit-implement` was ~**$1.33** Sonnet ([spec-driven-development.md](./spec-driven-development.md)).
+
+---
+
+### Phase 3 — Archive (cleanup and spec merge)
+
+```text
+/opsx:archive trust-registry-ai-jwks
+```
+
+**What archive does:**
+
+1. Checks artifacts and task completion (warns if tasks remain open)
+2. Offers to **sync** delta specs into `openspec/specs/<capability>/spec.md` if not already synced
+3. Moves the change folder to `openspec/changes/archive/YYYY-MM-DD-trust-registry-ai-jwks/`
+
+CLI equivalent:
+
+```sh
+openspec archive trust-registry-ai-jwks
+```
+
+After archive, `openspec/specs/jwks-endpoint/spec.md` is the merged source of truth for the capability.
+
+**Phase 3 (this run):** `/opsx:archive` (~1m 14s), same Claude Code session — included in Sonnet [Costs](#costs).
+
+**Session total (`/stats`):** **$2.00**, **7m 7s** API time (propose + apply + archive). The Claude Code footer showed ~65,801 cumulative “tokens” for the session; that meter includes cache-heavy context and does not match input+output alone — use `/stats` for billing (see [Costs](#costs)).
+
+---
+
+### Validate
+
+After implementation, validate locally:
+
+```sh
+docker compose -f docker-compose.validate.yml up -d --build
+```
+
+```bash
+(echo "=== CHECK 1: GET /.well-known/jwks.json ===" \
+  && STATUS=$(curl -s -o /tmp/jwks-all.json -w "%{http_code}" \
+    http://localhost:8000/.well-known/jwks.json) \
+  && echo "HTTP $STATUS" \
+  && cat /tmp/jwks-all.json | python3 -m json.tool 2>/dev/null \
+  || cat /tmp/jwks-all.json)
+
+(echo "=== CHECK 2: GET keyset JWKS ===" \
+  && STATUS=$(curl -s -o /tmp/jwks-set.json -w "%{http_code}" \
+    http://localhost:8000/keysets/signing/.well-known/jwks.json) \
+  && echo "HTTP $STATUS" \
+  && cat /tmp/jwks-set.json | python3 -m json.tool 2>/dev/null \
+  || cat /tmp/jwks-set.json)
+```
+
+`local/kong-validate/kong.yaml` defines test keys, keysets, routes, and the plugin attachment.
+
+---
+
+### Optional additional phases
+
+| Command | When to use |
+|---------|-------------|
+| `/opsx:explore` | Requirements unclear; compare approaches before proposing |
+| `/opsx:sync` | Merge delta specs into `openspec/specs/` before archive (archive can prompt) |
+| `/opsx:verify` | Check implementation vs artifacts before archive |
+| `/opsx:new` + `/opsx:continue` or `/opsx:ff` | Expanded workflow: step-by-step or fast-forward artifact creation instead of `/opsx:propose` |
+
+Enable expanded workflows:
+
+```sh
+openspec config profile   # select workflows
+openspec update
+```
+
+---
+
+### Follow-up updates and delta specs
+
+For bounded changes to an existing capability, add a new change with delta specs (`## ADDED Requirements`, `## MODIFIED Requirements`, etc.) instead of re-running the full propose flow.
+
+Simple guidance for when to update specs:
+
+- If a user of the plugin would notice the change → update the spec (via a new change + archive)
+- If only a developer reading the code would notice → direct edit may suffice
+
+---
+
+## Commentary
+
+### Approvals
+
+File changes and terminal commands require approval in Claude Code. Loosen guardrails once comfortable with the workflow.
+
+### Human intervention
+
+Edit any artifact (`proposal.md`, `design.md`, `tasks.md`, delta specs) between phases. OpenSpec expects iteration.
+
+### Did the model cheat?
+
+Wall-off rules live in [`.claude/settings.local.json`](../.claude/settings.local.json) (not committed):
+
+```json
+"deny": [
+  "Read(plugins/trust-registry/**)",
+  "Read(plugins/trust-registry-ai/**)",
+  "Read(specs/001-jwks-endpoint/**)"
+]
+```
+
+Run Claude Code with project root `~/kong-oss-plugins` so this file applies.
+
+**Verified after the OpenSpec run (2026-05-19):** Explicit `Read` requests for files under those three globs were **inaccessible** (denied as expected). Reads outside the globs (e.g. `plugins/trust-registry-ai-openspec/`) still worked. The deny rules are working for **`Read`**, not for every shell command.
+
+**During the run:** Watch the transcript for **search** or **`ls`** under `plugins/` — those can still reveal that `trust-registry` / `trust-registry-ai` exist without reading their contents (same limitation as the [Spec-Kit run](./spec-driven-development.md)).
+
+### Costs
+
+End-of-session usage from `/stats` in Claude Code (one session: propose → apply → archive):
+
+| Model        | Input | Output | Cache read | Cache write | Cost    |
+|--------------|-------|--------|------------|-------------|---------|
+| Opus 4.6     | 449   | 8.7k   | 934.7k     | 26.3k       | **$0.85** |
+| Sonnet 4.6   | 879   | 12.2k  | 2.2m       | 78.6k       | **$1.15** |
+| **Total**    |       | **~20.9k** |            |             | **$2.00** |
+
+- **API duration:** 7m 7s (matches phased work). Wall clock was longer (~56m) due to approvals and breaks.
+- **Phase mapping:** Opus row ≈ `/opsx:propose`; Sonnet row ≈ `/opsx:apply` + `/opsx:archive` + in-apply validation.
+- **Footer meter:** The UI reported ~65,801 session “tokens” at archive time; that count is not the same as input+output and is not used above.
+
+Rates: [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing). Reference: Spec-Kit run **~$3.98** total ([spec-driven-development.md](./spec-driven-development.md)) — OpenSpec **~50% lower** for this feature, with validation largely inside apply rather than a separate ~28K-token validation chat.
+
+**Archived to:** `openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/` · **Merged spec:** `openspec/specs/jwks-endpoint/spec.md`
+
+### Using other agents
+
+This run used **Claude Code** only. OpenSpec also supports Cursor, Codex, Windsurf, Gemini, GitHub Copilot, and others — see [OpenSpec integrations](https://github.com/Fission-AI/OpenSpec/blob/main/docs/cli.md) and `openspec init --tools <list>`.
+
+---
+
+## Related
+
+- [Spec-Kit README](./spec-driven-development.md) — prior approach
+- [Comparison report: human vs Spec-Kit AI](../specs/001-jwks-endpoint/comparison-report.md)
+- [Comparison report: human vs OpenSpec AI](../specs/001-jwks-endpoint/comparison-report-openspec.md)
+- [Comparison report: Spec-Kit vs OpenSpec](../specs/001-jwks-endpoint/speckit-vs-openspec.md)

--- a/local/kong-validate/Dockerfile
+++ b/local/kong-validate/Dockerfile
@@ -9,9 +9,9 @@ RUN if [ -x "$(command -v apk)" ]; then apk add --no-cache unzip curl; \
 
 WORKDIR /build
 
-COPY plugins/trust-registry-ai plugins/trust-registry-ai
+COPY plugins/trust-registry-ai-openspec plugins/trust-registry-ai-openspec
 
-RUN cd plugins/trust-registry-ai && luarocks make kong-plugin-trust-registry-ai-1.0.0-0.rockspec
+RUN cd plugins/trust-registry-ai-openspec && luarocks make kong-plugin-trust-registry-ai-openspec-1.0.0-0.rockspec
 
 USER kong
 WORKDIR /

--- a/local/kong-validate/kong.yaml
+++ b/local/kong-validate/kong.yaml
@@ -42,4 +42,4 @@ services:
           - GET
         strip_path: false
     plugins:
-      - name: trust-registry-ai
+      - name: trust-registry-ai-openspec

--- a/openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/design.md
+++ b/openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/design.md
@@ -1,0 +1,67 @@
+## Context
+
+Kong's `keys` and `key_sets` entities store cryptographic keys for an Edge Server, but there is no built-in way to publish those keys as a standard JWKS document. Other Edge Servers need to retrieve these public keys to verify JWS documents. The plugin `trust-registry-ai-openspec` will expose them via RFC 7517-compliant JWKS endpoints.
+
+The plugin lives in `plugins/trust-registry-ai-openspec/` and follows the same layout as existing plugins (handler.lua, schema.lua, rockspec). It operates in the `access` phase, intercepts matched routes, and returns a JSON response directly — it does not proxy upstream.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Serve a JWKS document containing all public keys from Kong's `keys` entity.
+- Support filtering by keyset via the `key_set` path parameter.
+- Convert PEM-formatted public keys to JWK objects automatically using `resty.openssl.pkey`.
+- Return keys that are already stored as JWK objects without conversion.
+- Require zero plugin configuration parameters.
+
+**Non-Goals:**
+
+- Key management (create, update, delete) — that is the Admin API's responsibility.
+- Caching or TTL headers — out of scope for the initial implementation.
+- Support for private key export — only public key material is served.
+- Support for symmetric keys (oct type) — only asymmetric keys (RSA, EC) are in scope.
+
+## Decisions
+
+### 1. Use `access` phase to short-circuit the request
+
+**Decision**: Handle the entire request in the `access` phase via `kong.response.exit()`.
+
+**Rationale**: The plugin produces a self-contained JSON response and does not need upstream proxying. The `access` phase is the standard point for plugins that generate responses directly. This matches the pattern used by other plugins in this repo (e.g., trust-hello uses `certificate`/`access` phases).
+
+**Alternative considered**: Using `content` phase — rejected because it requires more boilerplate and the `access` phase is simpler for direct responses.
+
+### 2. Use `kong.db.keys` and `kong.db.key_sets` for data access
+
+**Decision**: Query Kong's database layer directly via `kong.db.keys:each()` and `kong.db.key_sets:find_by_name()` (or equivalent page methods).
+
+**Rationale**: The Kong PDK exposes the DAO layer at `kong.db.<entity>`, which is the supported way to access core entities from within a plugin. This avoids internal HTTP calls to the Admin API.
+
+**Alternative considered**: Calling the Admin API via `resty.http` — rejected because it introduces a network hop, requires Admin API access from the data plane, and is less reliable.
+
+### 3. PEM-to-JWK conversion via `resty.openssl.pkey`
+
+**Decision**: Use `resty.openssl.pkey.new(pem_string)` followed by `:tostring("public", "JWK")` to convert PEM keys to JWK format.
+
+**Rationale**: `resty.openssl.pkey` is already a dependency in this repo and provides a high-level method to export a public key as a JWK JSON string. This avoids manual extraction of RSA/EC parameters and DER encoding, which is error-prone.
+
+**Alternative considered**: Manual parameter extraction (n, e for RSA; x, y, crv for EC) from the pkey object — rejected because `tostring` with JWK format handles this internally and is less code.
+
+### 4. Keyset filtering via Kong's DAO
+
+**Decision**: When a `key_set` path parameter is present, resolve it to a key_set ID via `kong.db.key_sets`, then filter keys by that foreign key.
+
+**Rationale**: Kong's `keys` entity has a `set` foreign key to `key_sets`. Querying `kong.db.keys:each()` and filtering by `set.id` is straightforward. Alternatively, use `kong.db.keys:page()` with a filter if Kong's DAO supports it for the `set` field.
+
+### 5. Response format
+
+**Decision**: Return `{ "keys": [...] }` with Content-Type `application/json`. Each key object includes `kty`, `kid`, `alg`, `use`, and the key-type-specific fields.
+
+**Rationale**: This matches the JWKS format defined in RFC 7517 Section 5. The `kid` field is populated from the Kong key entity's `kid` field (or `name` as fallback).
+
+## Risks / Trade-offs
+
+- **[Performance on large key sets]** → Iterating all keys via `kong.db.keys:each()` on every request could be slow if hundreds of keys exist. Mitigation: This is acceptable for the initial implementation; caching can be added later if needed.
+- **[PEM conversion failure]** → If a PEM key is malformed, `resty.openssl.pkey.new()` will error. Mitigation: Wrap in pcall, log the error, and skip the malformed key rather than failing the entire response.
+- **[Key set not found]** → If the `key_set` path parameter doesn't match any keyset. Mitigation: Return a 404 with a clear error message.
+- **[No keys available]** → If there are no keys (or none for the requested keyset). Mitigation: Return a valid JWKS document with an empty `keys` array — this is valid per RFC 7517.

--- a/openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/proposal.md
+++ b/openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+SDX Edge Server hosts need to publish their public keys so that other Edge Servers can validate JSON Web Signature (JWS) documents. Today there is no standardised JWKS endpoint backed by Kong's native `keys` and `keysets` entities, forcing operators to manage key distribution out-of-band.
+
+## What Changes
+
+- Add a new Kong plugin (`trust-registry-ai-openspec`) that serves a JWKS (RFC 7517) document from Kong's `keys` and `keysets` entities.
+- Expose two GET routes:
+  - `/.well-known/jwks.json` — returns all keys across all keysets.
+  - `/keysets/{key_set}/.well-known/jwks.json` — returns only the keys belonging to the named keyset.
+- Convert PEM-formatted public keys to JWK objects on-the-fly so the response always contains valid JWK entries.
+- The plugin requires no configuration parameters.
+
+## Capabilities
+
+### New Capabilities
+
+- `jwks-endpoint`: Serves a JWKS document from Kong's keys/keysets entities, with optional keyset filtering and PEM-to-JWK conversion.
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- **New plugin directory**: `plugins/trust-registry-ai-openspec/` with `handler.lua`, `schema.lua`, and rockspec.
+- **Kong entities used**: `keys`, `key_sets` (read-only via Kong PDK / Admin API).
+- **Dependencies**: `resty.openssl.pkey` (PEM→JWK conversion), `cjson` (JSON encoding).
+- **Routes**: Two new GET paths must be configured on a service/route that loads this plugin.

--- a/openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/specs/jwks-endpoint/spec.md
+++ b/openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/specs/jwks-endpoint/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: Plugin serves a JWKS document with all keys
+
+The `trust-registry-ai-openspec` plugin SHALL respond to `GET /.well-known/jwks.json` with a JSON document containing a `keys` array of all public keys from Kong's `keys` entity, formatted as JWK objects per RFC 7517.
+
+#### Scenario: All keys returned as JWKS
+
+- **WHEN** a GET request is made to `/.well-known/jwks.json`
+- **THEN** the response status MUST be 200, Content-Type MUST be `application/json`, and the body MUST be a JSON object with a `keys` array containing one JWK object per public key stored in Kong's `keys` entity.
+
+#### Scenario: No keys exist
+
+- **WHEN** a GET request is made to `/.well-known/jwks.json` and no keys are stored in Kong
+- **THEN** the response status MUST be 200 and the body MUST be `{ "keys": [] }`.
+
+### Requirement: Plugin filters keys by keyset path parameter
+
+The plugin SHALL respond to `GET /keysets/{key_set}/.well-known/jwks.json` with a JWKS document containing only the keys belonging to the named keyset.
+
+#### Scenario: Keys filtered by keyset name
+
+- **WHEN** a GET request is made to `/keysets/my-keyset/.well-known/jwks.json` and a keyset named `my-keyset` exists with associated keys
+- **THEN** the response status MUST be 200 and the `keys` array MUST contain only the JWK objects belonging to the `my-keyset` keyset.
+
+#### Scenario: Keyset not found
+
+- **WHEN** a GET request is made to `/keysets/nonexistent/.well-known/jwks.json` and no keyset named `nonexistent` exists
+- **THEN** the response status MUST be 404 and the body MUST contain an error message indicating the keyset was not found.
+
+#### Scenario: Keyset exists but has no keys
+
+- **WHEN** a GET request is made to `/keysets/empty-keyset/.well-known/jwks.json` and the keyset `empty-keyset` exists but has no associated keys
+- **THEN** the response status MUST be 200 and the body MUST be `{ "keys": [] }`.
+
+### Requirement: PEM public keys are converted to JWK format
+
+The plugin SHALL convert any public key stored in PEM format to a JWK object using `resty.openssl.pkey`. The resulting JWK MUST include the standard fields for the key type (e.g., `kty`, `n`, `e` for RSA; `kty`, `crv`, `x`, `y` for EC).
+
+#### Scenario: PEM RSA key converted to JWK
+
+- **WHEN** a key stored in Kong has a PEM-formatted RSA public key
+- **THEN** the JWKS response MUST include a JWK object with `kty` set to `RSA` and the `n` and `e` fields populated from the PEM key material.
+
+#### Scenario: PEM EC key converted to JWK
+
+- **WHEN** a key stored in Kong has a PEM-formatted EC public key
+- **THEN** the JWKS response MUST include a JWK object with `kty` set to `EC` and the `crv`, `x`, and `y` fields populated from the PEM key material.
+
+### Requirement: JWK-formatted keys are passed through without conversion
+
+The plugin SHALL include keys already stored in JWK format directly in the JWKS response without modification.
+
+#### Scenario: JWK key included as-is
+
+- **WHEN** a key stored in Kong has its `jwk` field populated with a valid JWK object
+- **THEN** the JWKS response MUST include that JWK object as-is in the `keys` array.
+
+### Requirement: Each JWK object includes a key identifier
+
+Each JWK object in the JWKS response SHALL include a `kid` field. The `kid` MUST be populated from the Kong key entity's `kid` field. If `kid` is not set on the entity, the key's `name` field SHALL be used as fallback.
+
+#### Scenario: kid field from key entity
+
+- **WHEN** a key entity has `kid` set to `"key-123"`
+- **THEN** the corresponding JWK object in the JWKS response MUST have `kid` set to `"key-123"`.
+
+#### Scenario: kid fallback to name
+
+- **WHEN** a key entity has no `kid` set but has `name` set to `"my-signing-key"`
+- **THEN** the corresponding JWK object in the JWKS response MUST have `kid` set to `"my-signing-key"`.
+
+### Requirement: Malformed keys are skipped gracefully
+
+The plugin SHALL skip any key that cannot be converted to a valid JWK object (e.g., malformed PEM data) and log a warning. The remaining valid keys MUST still be returned.
+
+#### Scenario: Malformed PEM key is skipped
+
+- **WHEN** a key entity has a PEM value that cannot be parsed by `resty.openssl.pkey`
+- **THEN** the JWKS response MUST omit that key, the remaining valid keys MUST still appear in the `keys` array, and a warning MUST be logged.
+
+### Requirement: Plugin requires no configuration
+
+The plugin schema SHALL define an empty `config` record with no fields. The plugin MUST operate without any user-supplied configuration parameters.
+
+#### Scenario: Plugin enabled with no config
+
+- **WHEN** the `trust-registry-ai-openspec` plugin is enabled on a route with no configuration
+- **THEN** the plugin MUST function correctly and serve JWKS responses.
+
+### Requirement: Only GET method is supported
+
+The plugin SHALL only respond to GET requests. Requests with other HTTP methods on the JWKS routes MUST be handled by Kong's default routing behavior (not intercepted by this plugin).
+
+#### Scenario: GET request is handled
+
+- **WHEN** a GET request is made to `/.well-known/jwks.json`
+- **THEN** the plugin MUST return a JWKS response.
+
+#### Scenario: POST request is not handled by plugin
+
+- **WHEN** a POST request is made to `/.well-known/jwks.json`
+- **THEN** the plugin MUST NOT intercept the request; Kong's default routing behavior applies.

--- a/openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/tasks.md
+++ b/openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/tasks.md
@@ -1,0 +1,27 @@
+## 1. Plugin Scaffolding
+
+- [x] 1.1 Create plugin directory `plugins/trust-registry-ai-openspec/src/` with `schema.lua` defining the plugin name `trust-registry-ai-openspec` and an empty config record
+- [x] 1.2 Create the rockspec file `plugins/trust-registry-ai-openspec/kong-plugin-trust-registry-ai-openspec-1.0.0-0.rockspec` with module declarations for handler, schema, and jwks modules
+
+## 2. Core JWKS Logic
+
+- [x] 2.1 Create `src/jwks.lua` with a function to query `kong.db.keys` and `kong.db.key_sets`, iterate over keys, and build the JWKS `keys` array
+- [x] 2.2 Implement PEM-to-JWK conversion in `src/jwks.lua` using `resty.openssl.pkey.new(pem):tostring("public", "JWK")` with pcall error handling to skip malformed keys
+- [x] 2.3 Implement JWK passthrough logic: if a key entity already has a `jwk` field populated, decode it and include it directly without conversion
+- [x] 2.4 Implement `kid` population: use the key entity's `kid` field, falling back to `name` if `kid` is not set
+- [x] 2.5 Implement keyset filtering: accept an optional `key_set` name parameter, resolve it via `kong.db.key_sets`, and filter keys by the matching set ID. Return 404 if the keyset name is not found.
+
+## 3. Handler
+
+- [x] 3.1 Create `src/handler.lua` with an `access` phase handler that extracts the optional `key_set` path parameter from `kong.router.get_route()` or `ngx.ctx.router_matches.uri_captures`
+- [x] 3.2 Call the jwks module to build the JWKS response and return it via `kong.response.exit(200, body, headers)` with Content-Type `application/json`
+
+## 4. Kong Declarative Configuration
+
+- [x] 4.1 Add the plugin route entries to `local/kong-validate/kong.yaml` with the two paths (`/.well-known/jwks.json` and `~/keysets/(?<key_set>.+)/.well-known/jwks.json`) and GET method only
+
+## 5. Validation
+
+- [x] 5.1 Run the Kong validation Docker setup to confirm the plugin loads without errors
+- [x] 5.2 Verify JWKS endpoint returns valid JSON with correct structure for the all-keys route
+- [x] 5.3 Verify keyset-filtered route returns only keys for the specified keyset

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,17 @@
+schema: spec-driven
+
+context: |
+  Kong OSS plugin repository. Lua (LuaJIT), Kong PDK only.
+  Plugin layout: plugins/<name>/src/{handler,schema}.lua + rockspec.
+  Follow patterns from existing plugins; do not read plugins/trust-registry or plugins/trust-registry-ai.
+  Output plugin: plugins/trust-registry-ai-openspec/
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/jwks-endpoint/spec.md
+++ b/openspec/specs/jwks-endpoint/spec.md
@@ -1,0 +1,101 @@
+### Requirement: Plugin serves a JWKS document with all keys
+
+The `trust-registry-ai-openspec` plugin SHALL respond to `GET /.well-known/jwks.json` with a JSON document containing a `keys` array of all public keys from Kong's `keys` entity, formatted as JWK objects per RFC 7517.
+
+#### Scenario: All keys returned as JWKS
+
+- **WHEN** a GET request is made to `/.well-known/jwks.json`
+- **THEN** the response status MUST be 200, Content-Type MUST be `application/json`, and the body MUST be a JSON object with a `keys` array containing one JWK object per public key stored in Kong's `keys` entity.
+
+#### Scenario: No keys exist
+
+- **WHEN** a GET request is made to `/.well-known/jwks.json` and no keys are stored in Kong
+- **THEN** the response status MUST be 200 and the body MUST be `{ "keys": [] }`.
+
+### Requirement: Plugin filters keys by keyset path parameter
+
+The plugin SHALL respond to `GET /keysets/{key_set}/.well-known/jwks.json` with a JWKS document containing only the keys belonging to the named keyset.
+
+#### Scenario: Keys filtered by keyset name
+
+- **WHEN** a GET request is made to `/keysets/my-keyset/.well-known/jwks.json` and a keyset named `my-keyset` exists with associated keys
+- **THEN** the response status MUST be 200 and the `keys` array MUST contain only the JWK objects belonging to the `my-keyset` keyset.
+
+#### Scenario: Keyset not found
+
+- **WHEN** a GET request is made to `/keysets/nonexistent/.well-known/jwks.json` and no keyset named `nonexistent` exists
+- **THEN** the response status MUST be 404 and the body MUST contain an error message indicating the keyset was not found.
+
+#### Scenario: Keyset exists but has no keys
+
+- **WHEN** a GET request is made to `/keysets/empty-keyset/.well-known/jwks.json` and the keyset `empty-keyset` exists but has no associated keys
+- **THEN** the response status MUST be 200 and the body MUST be `{ "keys": [] }`.
+
+### Requirement: PEM public keys are converted to JWK format
+
+The plugin SHALL convert any public key stored in PEM format to a JWK object using `resty.openssl.pkey`. The resulting JWK MUST include the standard fields for the key type (e.g., `kty`, `n`, `e` for RSA; `kty`, `crv`, `x`, `y` for EC).
+
+#### Scenario: PEM RSA key converted to JWK
+
+- **WHEN** a key stored in Kong has a PEM-formatted RSA public key
+- **THEN** the JWKS response MUST include a JWK object with `kty` set to `RSA` and the `n` and `e` fields populated from the PEM key material.
+
+#### Scenario: PEM EC key converted to JWK
+
+- **WHEN** a key stored in Kong has a PEM-formatted EC public key
+- **THEN** the JWKS response MUST include a JWK object with `kty` set to `EC` and the `crv`, `x`, and `y` fields populated from the PEM key material.
+
+### Requirement: JWK-formatted keys are passed through without conversion
+
+The plugin SHALL include keys already stored in JWK format directly in the JWKS response without modification.
+
+#### Scenario: JWK key included as-is
+
+- **WHEN** a key stored in Kong has its `jwk` field populated with a valid JWK object
+- **THEN** the JWKS response MUST include that JWK object as-is in the `keys` array.
+
+### Requirement: Each JWK object includes a key identifier
+
+Each JWK object in the JWKS response SHALL include a `kid` field. The `kid` MUST be populated from the Kong key entity's `kid` field. If `kid` is not set on the entity, the key's `name` field SHALL be used as fallback.
+
+#### Scenario: kid field from key entity
+
+- **WHEN** a key entity has `kid` set to `"key-123"`
+- **THEN** the corresponding JWK object in the JWKS response MUST have `kid` set to `"key-123"`.
+
+#### Scenario: kid fallback to name
+
+- **WHEN** a key entity has no `kid` set but has `name` set to `"my-signing-key"`
+- **THEN** the corresponding JWK object in the JWKS response MUST have `kid` set to `"my-signing-key"`.
+
+### Requirement: Malformed keys are skipped gracefully
+
+The plugin SHALL skip any key that cannot be converted to a valid JWK object (e.g., malformed PEM data) and log a warning. The remaining valid keys MUST still be returned.
+
+#### Scenario: Malformed PEM key is skipped
+
+- **WHEN** a key entity has a PEM value that cannot be parsed by `resty.openssl.pkey`
+- **THEN** the JWKS response MUST omit that key, the remaining valid keys MUST still appear in the `keys` array, and a warning MUST be logged.
+
+### Requirement: Plugin requires no configuration
+
+The plugin schema SHALL define an empty `config` record with no fields. The plugin MUST operate without any user-supplied configuration parameters.
+
+#### Scenario: Plugin enabled with no config
+
+- **WHEN** the `trust-registry-ai-openspec` plugin is enabled on a route with no configuration
+- **THEN** the plugin MUST function correctly and serve JWKS responses.
+
+### Requirement: Only GET method is supported
+
+The plugin SHALL only respond to GET requests. Requests with other HTTP methods on the JWKS routes MUST be handled by Kong's default routing behavior (not intercepted by this plugin).
+
+#### Scenario: GET request is handled
+
+- **WHEN** a GET request is made to `/.well-known/jwks.json`
+- **THEN** the plugin MUST return a JWKS response.
+
+#### Scenario: POST request is not handled by plugin
+
+- **WHEN** a POST request is made to `/.well-known/jwks.json`
+- **THEN** the plugin MUST NOT intercept the request; Kong's default routing behavior applies.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -14,6 +14,8 @@
 | trust-jwks             | Verify a jwks document originated from the same domain TLS that it is hosted on   |
 | trust-sign             | Builds an rfc-9421 HTTP Message Signature                                         |
 | trust-registry         | Returns a JWKS document listing trusted public keys                               |
+| trust-registry-ai      | JWKS endpoint (Spec-Kit AI-generated)                                             |
+| trust-registry-ai-openspec | JWKS endpoint (OpenSpec AI-generated)                                         |
 | trust-timestamp        | Calls a Timestamping Authority using the RFC-3161 Time-Stamp Protocol             |
 | trust-ledger           | Log RFC-3161 message to an Immutable Ledger                                       |
 | trust-verify-digest    | Verify that the content-digest matches the payload body                           |

--- a/plugins/trust-registry-ai-openspec/kong-plugin-trust-registry-ai-openspec-1.0.0-0.rockspec
+++ b/plugins/trust-registry-ai-openspec/kong-plugin-trust-registry-ai-openspec-1.0.0-0.rockspec
@@ -1,0 +1,36 @@
+local plugin_name = "trust-registry-ai-openspec"
+local package_name = "kong-plugin-" .. plugin_name
+local package_version = "1.0.0"
+local rockspec_revision = "0"
+
+package = package_name
+version = package_version .. "-" .. rockspec_revision
+supported_platforms = { "linux", "macosx" }
+
+source = {
+  url = "git://github.com/bcgov/kong-oss-plugins",
+  tag = "v1.0.0",
+  dir = "plugins/trust-registry-ai-openspec/src"
+}
+
+description = {
+  summary = "Kong Gateway plugin that exposes Kong keys and keysets as a JWKS endpoint.",
+  detailed = [[
+      kong-plugin-trust-registry-ai-openspec serves public keys from Kong's
+      keys and key_sets entities as a RFC 7517 JWKS document, enabling
+      SDX Edge Server hosts to publish their public keys for JWS verification.
+  ]],
+  homepage = "https://github.com/bcgov/kong-oss-plugins/plugins/trust-registry-ai-openspec",
+  license = "Apache 2.0",
+}
+
+dependencies = {}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["kong.plugins." .. plugin_name .. ".handler"] = "src/handler.lua",
+    ["kong.plugins." .. plugin_name .. ".schema"]  = "src/schema.lua",
+    ["kong.plugins." .. plugin_name .. ".jwks"]    = "src/jwks.lua",
+  }
+}

--- a/plugins/trust-registry-ai-openspec/src/handler.lua
+++ b/plugins/trust-registry-ai-openspec/src/handler.lua
@@ -1,0 +1,32 @@
+local cjson = require "cjson"
+local kong_meta = require "kong.meta"
+local jwks = require "kong.plugins.trust-registry-ai-openspec.jwks"
+
+local TrustRegistryAiOpenspecHandler = {
+  PRIORITY = 950,
+  VERSION = kong_meta.version
+}
+
+function TrustRegistryAiOpenspecHandler:access(conf)
+  local path = kong.request.get_path()
+
+  local key_set_name
+  local m = ngx.re.match(path, [[^/keysets/(.+)/.well-known/jwks\.json$]], "jo")
+  if m then
+    key_set_name = m[1]
+  end
+
+  local body, status, err = jwks.build_jwks(key_set_name)
+  if err then
+    if status == 404 then
+      return kong.response.exit(404, { message = err })
+    end
+    return kong.response.exit(500, { message = err })
+  end
+
+  return kong.response.exit(status, cjson.encode(body), {
+    ["Content-Type"] = "application/json"
+  })
+end
+
+return TrustRegistryAiOpenspecHandler

--- a/plugins/trust-registry-ai-openspec/src/jwks.lua
+++ b/plugins/trust-registry-ai-openspec/src/jwks.lua
@@ -1,0 +1,101 @@
+local cjson = require "cjson.safe"
+local openssl_pkey = require "resty.openssl.pkey"
+
+local _M = {}
+
+local function pem_to_jwk(pem)
+  local ok, pkey_or_err = pcall(openssl_pkey.new, pem)
+  if not ok or not pkey_or_err then
+    return nil, "failed to parse PEM key: " .. tostring(pkey_or_err)
+  end
+  local pkey = pkey_or_err
+  local ok2, jwk_str_or_err = pcall(function()
+    return pkey:tostring("public", "JWK")
+  end)
+  if not ok2 or not jwk_str_or_err then
+    return nil, "failed to export JWK: " .. tostring(jwk_str_or_err)
+  end
+  local jwk, err = cjson.decode(jwk_str_or_err)
+  if err then
+    return nil, "failed to decode exported JWK: " .. err
+  end
+  return jwk, nil
+end
+
+local function build_key_entry(key_entity)
+  local jwk
+
+  if key_entity.jwk and key_entity.jwk ~= ngx.null then
+    local decoded, err = cjson.decode(key_entity.jwk)
+    if err then
+      return nil, "failed to decode stored JWK: " .. err
+    end
+    jwk = decoded
+  elseif key_entity.pem and key_entity.pem ~= ngx.null then
+    local pub = key_entity.pem.public_key
+    if not pub or pub == ngx.null then
+      return nil, "no public_key in pem field"
+    end
+    local converted, err = pem_to_jwk(pub)
+    if err then
+      return nil, err
+    end
+    jwk = converted
+  else
+    return nil, "key entity has neither jwk nor pem fields"
+  end
+
+  local kid = key_entity.kid
+  if not kid or kid == ngx.null or kid == "" then
+    kid = key_entity.name
+  end
+  if kid and kid ~= ngx.null then
+    jwk.kid = kid
+  end
+
+  return jwk, nil
+end
+
+function _M.build_jwks(key_set_name)
+  local set_id
+
+  if key_set_name then
+    local key_set, err = kong.db.key_sets:select_by_name(key_set_name)
+    if err then
+      return nil, 500, "error looking up keyset: " .. err
+    end
+    if not key_set then
+      return nil, 404, "keyset not found: " .. key_set_name
+    end
+    set_id = key_set.id
+  end
+
+  local keys_list = {}
+
+  for key_entity, err in kong.db.keys:each() do
+    if err then
+      kong.log.warn("error iterating keys: ", err)
+      break
+    end
+
+    if set_id then
+      local entity_set_id = key_entity.set and key_entity.set.id
+      if entity_set_id ~= set_id then
+        goto continue
+      end
+    end
+
+    local jwk, build_err = build_key_entry(key_entity)
+    if build_err then
+      kong.log.warn("skipping key '", key_entity.name, "': ", build_err)
+    else
+      keys_list[#keys_list + 1] = jwk
+    end
+
+    ::continue::
+  end
+
+  return { keys = keys_list }, 200, nil
+end
+
+return _M

--- a/plugins/trust-registry-ai-openspec/src/schema.lua
+++ b/plugins/trust-registry-ai-openspec/src/schema.lua
@@ -1,0 +1,14 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+return {
+  name = "trust-registry-ai-openspec",
+  fields = {
+    { protocols = typedefs.protocols_http },
+    {
+      config = {
+        type = "record",
+        fields = {}
+      }
+    }
+  }
+}

--- a/specs/001-jwks-endpoint/comparison-report-openspec.md
+++ b/specs/001-jwks-endpoint/comparison-report-openspec.md
@@ -1,0 +1,161 @@
+# Comparison Report: trust-registry (Human) vs trust-registry-ai-openspec (OpenSpec AI)
+
+**Date**: 2026-05-19  
+**Scope**: Plugin code comparison + process observations for the OpenSpec run  
+**OpenSpec change**: `openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/` (archived)  
+**Merged spec**: `openspec/specs/jwks-endpoint/spec.md`  
+**Plugin**: `plugins/trust-registry-ai-openspec/`
+
+For the Spec-Kit AI plugin, see [comparison-report.md](./comparison-report.md). For workflow comparison, see [speckit-vs-openspec.md](./speckit-vs-openspec.md).
+
+## Validation (2026-05-19)
+
+Local validation via `docker compose -f docker-compose.validate.yml up -d --build`:
+
+| Check | Result |
+|-------|--------|
+| `GET /.well-known/jwks.json` | HTTP 200 — `keys` contains EC JWK (`ec-jwk-key-1`, passthrough) and RSA JWK (`rsa-pem-key-1`, PEM→JWK) |
+| `GET /keysets/signing/.well-known/jwks.json` | HTTP 200 — `keys` contains only RSA key from `signing` keyset |
+
+Example (abbreviated):
+
+```json
+// GET /.well-known/jwks.json
+{ "keys": [
+    { "kty": "EC", "kid": "ec-jwk-key-1", "crv": "P-256", ... },
+    { "kty": "RSA", "kid": "rsa-pem-key-1", "e": "AQAB", "n": "..." }
+]}
+
+// GET /keysets/signing/.well-known/jwks.json
+{ "keys": [
+    { "kty": "RSA", "kid": "rsa-pem-key-1", "e": "AQAB", "n": "..." }
+]}
+```
+
+**Conclusion:** Core MVP behavior works. PEM conversion and keyset filtering match the story.
+
+---
+
+## Structure
+
+```text
+plugins/trust-registry/                 # human
+  src/handler.lua, pem_to_jwks.lua, schema.lua
+
+plugins/trust-registry-ai-openspec/     # OpenSpec AI
+  src/handler.lua, jwks.lua, schema.lua
+```
+
+OpenSpec split JWKS assembly into `jwks.lua`; the human plugin keeps logic in `handler.lua` with a small PEM helper module.
+
+---
+
+## Code-Level Comparison
+
+### 1. PEM-to-JWK conversion
+
+| | Human (`pem_to_jwks.lua`) | OpenSpec (`jwks.lua` internal) |
+|---|---------------------------|--------------------------------|
+| **Approach** | `pkey:tostring("public", "JWK")` | Same |
+| **Lines** | ~25 | ~20 (inline in `jwks.lua`) |
+| **pcall wrapping** | No | Yes (parse + export) |
+
+Both use the correct OpenSSL primitive. OpenSpec’s `design.md` chose this path up front (no manual `n`/`e` extraction rabbit hole).
+
+**Minor gap:** Human and Spec-Kit AI add `use = "sig"` on PEM-derived JWKs. OpenSpec output omits `use` in validated responses (not required by story, but a small interoperability difference).
+
+### 2. Keyset path resolution
+
+| | Human | OpenSpec |
+|---|-------|----------|
+| **Method** | `kong.request.get_uri_captures()` → `params.named.key_set` | `ngx.re.match` on `kong.request.get_path()` |
+| **Config fallback** | Optional `key_set` in schema | None (zero config) |
+| **Key iteration (filtered)** | `kong.db.keys:each_for_set({ id })` | `kong.db.keys:each()` + filter by `key_entity.set.id` |
+
+OpenSpec did **not** use `kong.request.get_uri_captures()` despite `tasks.md` mentioning `kong.router.get_route()` / `ngx.ctx.router_matches`. The implemented `ngx.re.match` works for the validated routes but is a different PDK pattern than the human plugin.
+
+### 3. Unknown / missing keyset
+
+| | Human | OpenSpec |
+|---|-------|----------|
+| **Unknown keyset name** | HTTP **404** `{ message: "Key set not found" }` | HTTP **404** `{ message: "keyset not found: …" }` |
+
+OpenSpec’s archived delta spec included a scenario for HTTP 200 + empty `keys` on unknown keyset; **implementation followed `tasks.md` (404)** instead. Behavior aligns with human plugin and Spec-Kit AI, not that delta scenario.
+
+### 4. Schema and configuration
+
+| | Human | OpenSpec |
+|---|-------|----------|
+| **Config** | Optional `key_set` string | Empty record (zero fields) |
+
+OpenSpec matches the story’s “no configuration parameters.” Human’s optional `key_set` is more flexible for operators (see [comparison-report.md](./comparison-report.md) Issue 2).
+
+### 5. Error handling
+
+| Scenario | Human | OpenSpec |
+|----------|-------|----------|
+| `select_by_name` DB error | Not checked (nil only) | Returns **500** |
+| Key iteration error | Logs, may return empty body | Logs warn, breaks loop |
+| Bad PEM / JWK | Logs, skips key | Logs warn, skips key |
+| Malformed stored JWK | Assumes decode succeeds | `cjson.safe` decode, skip with warn |
+
+OpenSpec is more defensive on DB errors. Human has debug `kong.log.warn` on URI captures left in production code.
+
+### 6. Response encoding
+
+| | Human | OpenSpec |
+|---|-------|----------|
+| **Response** | `kong.response.exit(200, { keys = ... })` (table) | `kong.response.exit(200, cjson.encode(body), …)` (pre-encoded string) |
+
+Both produce valid JSON in validation. OpenSpec’s pre-encoding is slightly non-idiomatic but functional.
+
+---
+
+## Scorecard
+
+| Dimension | Human | OpenSpec AI | Notes |
+|-----------|-------|-------------|-------|
+| **PEM simplicity** | ✓ | ✓ | Same OpenSSL approach |
+| **Spec/story compliance (zero config)** | Close | ✓ | |
+| **Operational flexibility** | ✓ | — | Config `key_set` fallback |
+| **Error handling** | — | ✓ | DB errors, pcall |
+| **PDK idioms** | ✓ | Close | `get_uri_captures` + `each_for_set` vs regex + full scan |
+| **Validation** | (baseline) | ✓ | curl checks passed |
+
+**Overall:** OpenSpec produced a **working, maintainable** plugin with correct PEM strategy and passing local validation. Trade-offs: modular `jwks.lua` (good), full key scan for keyset filter (acceptable at scale), no `use: sig` on converted keys (minor), path capture via regex instead of URI captures (document in ops runbooks).
+
+---
+
+## Spec / Process Refinement Observations
+
+### Issue 1: Delta spec vs implementation (unknown keyset) — resolved at archive
+
+During propose, an intermediate delta draft used HTTP 200 + empty `keys` for an unknown keyset. **Implementation and `tasks.md` used 404**, matching the human and Spec-Kit plugins.
+
+**After `/opsx:archive`:** `openspec/specs/jwks-endpoint/spec.md` requires **404** for a missing keyset (“Keyset not found” scenario). That matches `plugins/trust-registry-ai-openspec/` (`jwks.lua` returns 404). **No follow-up delta is required** for this ticket.
+
+**Refinement for future runs:** Run `/opsx:verify` before archive to catch spec/code drift earlier.
+
+### Issue 2: tasks.md PDK names vs what shipped
+
+Tasks referenced `kong.router.get_route()` / `ngx.ctx.router_matches`; code uses `ngx.re.match` on path. Worked in validation but shows task artifact drift from implementation.
+
+**Refinement:** Optional `/opsx:verify` or human review of tasks after apply.
+
+### Issue 3: No tests in output
+
+Neither OpenSpec `tasks.md` nor Spec-Kit constitution produced busted tests for this feature. Validation was manual (Docker + curl), which matched Spec-Kit’s interactive validation pattern.
+
+**Refinement:** Add to `openspec/config.yaml` context: “Include busted unit test tasks for each acceptance scenario.”
+
+### Comparison methodology (not an issue)
+
+OpenSpec `/opsx:propose` used the **same story text** as Spec-Kit `/speckit-specify`, plus the `/speckit-plan`-equivalent naming line (`trust-registry-ai-openspec` in a separate plugin directory). No extra hints (e.g. “survey lua-resty-openssl”) were added beyond what Spec-Kit received. That keeps the workflow/cost/code comparison fair; only the tooling and phase count differ.
+
+---
+
+## Related
+
+- [OpenSpec README](../../docs/openspec-readme.md)
+- [Spec-Kit vs OpenSpec](./speckit-vs-openspec.md)
+- [Human vs Spec-Kit AI](./comparison-report.md)

--- a/specs/001-jwks-endpoint/speckit-vs-openspec.md
+++ b/specs/001-jwks-endpoint/speckit-vs-openspec.md
@@ -1,0 +1,134 @@
+# Comparison Report: Spec-Kit vs OpenSpec
+
+**Date**: 2026-05-19  
+**Feature**: JWKS endpoint Kong plugin (same user story for both runs)  
+**Spec-Kit plugin**: `plugins/trust-registry-ai/` — `specs/001-jwks-endpoint/`  
+**OpenSpec plugin**: `plugins/trust-registry-ai-openspec/` — archived change `openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/`, merged spec `openspec/specs/jwks-endpoint/spec.md`
+
+## Executive summary
+
+Both tools delivered a **working JWKS publisher** against the same story. OpenSpec used **fewer steps** and **lower cost** (**$2.00** vs **$3.98** per `/stats`); Spec-Kit produced **more planning artifacts** (constitution, research, quickstart, contracts, checklists).
+
+On code quality for this run:
+
+- **Spec-Kit** initially over-engineered PEM conversion (manual extraction), later corrected to OpenSSL JWK export in a follow-up commit. Final `trust-registry-ai` is solid.
+- **OpenSpec** chose OpenSSL JWK export in `design.md` on the first pass — no manual-extraction detour — with logic split across `handler.lua` + `jwks.lua`.
+
+Neither workflow generated automated tests without explicit prompting. Both relied on Docker + curl validation.
+
+**Recommendation:** Prefer **OpenSpec** as the default SDD entry for new Kong work (lighter loop, archive/sync for spec drift). Keep Spec-Kit-style depth when you want constitution + research + quickstart in one toolchain, or stay on OpenSpec and add optional `/opsx:explore` / richer `design.md` for hard problems.
+
+---
+
+## Workflow comparison
+
+| Aspect | Spec-Kit | OpenSpec (`core` profile) |
+|--------|----------|-----------------------------|
+| **Planning** | 4 commands: constitution, specify, plan, tasks | 1 command: `/opsx:propose` |
+| **Implement** | `/speckit-implement` | `/opsx:apply` |
+| **Cleanup** | Manual | `/opsx:archive` (+ spec sync) |
+| **Wall-clock (this run)** | Not recorded | ~7m 7s (propose + apply + archive) |
+| **Artifact volume** | High (`spec.md`, `plan.md`, `research.md`, `quickstart.md`, …) | Lean (`proposal`, `design`, `tasks`, delta `specs/`) |
+| **Brownfield** | Full re-spec typical | Delta specs + archive merge |
+| **Iteration** | Edit markdown between steps | Same; encouraged |
+
+### Phase mapping
+
+```text
+Spec-Kit                          OpenSpec (core)
+────────                          ───────────────
+/speckit-constitution      ─┐
+/speckit-specify           ─┼──►  /opsx:propose     (Opus 4.6)
+/speckit-plan              ─┤
+/speckit-tasks             ─┘
+/speckit-implement       ──────►  /opsx:apply        (Sonnet 4.6)
+(manual spec sync)       ──────►  /opsx:archive
+```
+
+---
+
+## Cost and usage (Claude Code `/stats`, this repo)
+
+Single OpenSpec session (propose → apply → archive). Spec-Kit figures from [spec-driven-development.md](../../docs/spec-driven-development.md).
+
+| | Spec-Kit | OpenSpec |
+|---|----------|----------|
+| **Total cost** | **~$3.98** | **~$2.00** |
+| **API duration** | Not recorded | **7m 7s** |
+| **Opus 4.6** | 172 in / 104.3k out → **~$2.61** | 449 in / 8.7k out → **~$0.85** (propose) |
+| **Sonnet 4.6** | 1.8k in / 88.2k out → **~$1.33** | 879 in / 12.2k out → **~$1.15** (apply + archive + in-apply checks) |
+| **Haiku 4.5** | ~$0.04 | (negligible / not listed) |
+
+OpenSpec also reported large **cache read** volumes (934.7k Opus, 2.2m Sonnet), which keep billed cost down versus raw output token counts.
+
+**Workflow difference:** Spec-Kit used a separate Sonnet phase for interactive Docker validation (~28K footer tokens in that doc). OpenSpec folded Docker/curl checks into apply tasks 5.1–5.3 plus manual curl outside the session.
+
+**Note:** The Claude Code session footer showed ~65,801 cumulative “tokens” at archive; `/stats` is the authoritative billing view (~21k output tokens, **$2.00** total). Do not compare footer meters directly to Spec-Kit `/stats` output columns.
+
+Reference: [openspec-readme.md](../../docs/openspec-readme.md) (Costs section).
+
+---
+
+## Output comparison
+
+| Output | Spec-Kit | OpenSpec |
+|--------|----------|----------|
+| Requirements spec | `specs/001-jwks-endpoint/spec.md` | Delta → `openspec/specs/jwks-endpoint/spec.md` |
+| Design / research | `plan.md`, `research.md` | `design.md` |
+| Tasks | `tasks.md` | `tasks.md` |
+| Guardrails | `.specify/memory/constitution.md` | `openspec/config.yaml` `context` |
+| Extras | quickstart, data-model, contracts, checklists | None (unless expanded workflow) |
+| Plugin directory | `plugins/trust-registry-ai/` | `plugins/trust-registry-ai-openspec/` |
+
+---
+
+## Code outcome (three-way)
+
+Validated OpenSpec plugin 2026-05-19 with `docker compose -f docker-compose.validate.yml` + curl (see [comparison-report-openspec.md](./comparison-report-openspec.md)).
+
+| Dimension | Human `trust-registry` | Spec-Kit `trust-registry-ai` | OpenSpec `trust-registry-ai-openspec` |
+|-----------|------------------------|------------------------------|---------------------------------------|
+| PEM→JWK | OpenSSL JWK export | OpenSSL JWK export (after follow-up) | OpenSSL JWK export (first pass) |
+| URI / keyset | `get_uri_captures()` + config | `get_path():match` | `ngx.re.match` on path |
+| Keyset query | `each_for_set` | `each_for_set` | `each()` + filter in Lua |
+| Unknown keyset | 404 | 404 | 404 |
+| Config fields | Optional `key_set` | Zero | Zero |
+| `use: sig` on PEM keys | Yes | Yes | No (in curl output) |
+| Module layout | handler + pem helper | handler + pem_to_jwk | handler + jwks |
+| Local validation | (baseline) | Passed (per Spec-Kit doc) | **Passed** (curl) |
+
+**Rabbit hole avoided (OpenSpec):** Manual PEM parameter extraction (Spec-Kit’s original mistake, documented in [comparison-report.md](./comparison-report.md)).
+
+**Rabbit holes / drift (OpenSpec):** tasks.md cited wrong PDK helpers. Unknown-keyset behavior was 404 in code; merged `openspec/specs/jwks-endpoint/spec.md` matches (archive corrected an earlier 200-empty draft).
+
+---
+
+## Ticket criteria: OpenSpec benefits
+
+| Claim | Result |
+|-------|--------|
+| Lighter 3-phase workflow | **Yes** — propose / apply / archive vs 5–7 Spec-Kit steps |
+| Less upfront overhead | **Yes** — ~$0.85 Opus propose vs ~$2.61 Spec-Kit planning; fewer files |
+| Iterative proposals | **Yes** — artifacts editable between phases |
+| Spec drift / archive | **Yes** — merged `openspec/specs/jwks-endpoint/spec.md`, archive folder retained |
+| Brownfield / delta specs | **Supported** — not exercised on this greenfield plugin |
+| Same models as Spec-Kit | **Yes** — Opus 4.6 propose, Sonnet 4.6 apply |
+
+---
+
+## Recommendations / next steps
+
+1. **Default to OpenSpec** for new plugins; put repo conventions in `openspec/config.yaml` `context`.
+2. **Keep comparison plugins separate** — `trust-registry-ai` (Spec-Kit) vs `trust-registry-ai-openspec` (OpenSpec); do not overwrite when re-running either tool.
+3. **Before archive**, consider `/opsx:verify` to catch delta-spec vs implementation mismatches (e.g. unknown keyset status code).
+4. **Tests:** Add explicit test tasks in propose prompt or config rules if busted coverage is required (both tools skipped tests here).
+5. **Optional:** Run Spec-Kit validation token phase vs OpenSpec “validation in apply” when comparing total cost of “done and verified.”
+
+---
+
+## Related
+
+- [OpenSpec README](../../docs/openspec-readme.md)
+- [Spec-Kit README](../../docs/spec-driven-development.md)
+- [Human vs Spec-Kit AI](./comparison-report.md)
+- [Human vs OpenSpec AI](./comparison-report-openspec.md)


### PR DESCRIPTION
## Summary

This branch captures an end-to-end spec-driven development (SDD) experiment using [OpenSpec](https://github.com/Fission-AI/OpenSpec) + Claude Code to generate a Kong plugin, alongside the existing Spec-Kit and human implementations for comparison.

- **New plugin**: `plugins/trust-registry-ai-openspec/` — AI-generated Kong plugin that exposes `/.well-known/jwks.json` and `~/keysets/<key_set>/.well-known/jwks.json` by translating Kong `keys`/`keysets` into a JWKS (RFC 7517) response.
- **OpenSpec artifacts**:
  - `openspec/changes/archive/2026-05-19-trust-registry-ai-jwks/` — archived change (`proposal.md`, `design.md`, `tasks.md`, delta specs).
  - `openspec/specs/jwks-endpoint/spec.md` — merged source-of-truth spec after `/opsx:archive`.
  - `openspec/config.yaml` — project context for Kong plugin conventions.
  - `.claude/commands/opsx/` and `.claude/skills/openspec-*` — Claude Code integration from `openspec init --tools claude`.
- **Local validation harness**: `docker-compose.validate.yml` and `local/kong-validate/` configured for `trust-registry-ai-openspec` so teammates can reproduce JWKS checks against a running Kong.
- **Review docs for the team**:
  - [docs/openspec-readme.md](./openspec-readme.md) — walkthrough of the 3-phase OpenSpec flow (propose → apply → archive), costs from `/stats`, and clean-room notes.
  - [specs/001-jwks-endpoint/comparison-report-openspec.md](../specs/001-jwks-endpoint/comparison-report-openspec.md) — human `trust-registry` vs OpenSpec `trust-registry-ai-openspec` (code, validation, process observations).
  - [specs/001-jwks-endpoint/speckit-vs-openspec.md](../specs/001-jwks-endpoint/speckit-vs-openspec.md) — workflow, cost, and outcome comparison between Spec-Kit and OpenSpec, with recommendations.

**Unchanged baselines for comparison:**

- `plugins/trust-registry/` — human-authored reference plugin.
- `plugins/trust-registry-ai/` — Spec-Kit AI plugin (not modified on this branch).
- `specs/001-jwks-endpoint/` — Spec-Kit SDD artifacts (`spec.md`, `plan.md`, `research.md`, etc.) remain as-is except for the new comparison documents above.

## Test plan

- `docker compose -f docker-compose.validate.yml up -d --build`
- `curl -s http://localhost:8000/.well-known/jwks.json` — HTTP 200, `keys` includes EC + RSA test keys
- `curl -s http://localhost:8000/keysets/signing/.well-known/jwks.json` — HTTP 200, RSA keyset key only
- Skim `speckit-vs-openspec.md` for workflow/cost takeaways
